### PR TITLE
Avoid warnings from SILE when setting languages it does not explicitly support

### DIFF
--- a/tests/issues.sil
+++ b/tests/issues.sil
@@ -1,6 +1,16 @@
 \begin[class=fontproof]{document}
 \bidi-off
 
+% Suppress unneeded warnings about languages SILE doesn't have hyphenation or
+% localizations for. Remove when SILE handles this gracefully, see:
+% - https://github.com/sile-typesetter/fontproof/issues/52
+% - https://github.com/sile-typesetter/sile/issues/2229
+\begin{lua}
+SILE.scratch.loaded_languages.dflt = true
+SILE.scratch.loaded_languages.ksw = true
+SILE.scratch.loaded_languages.tjl = true
+\end{lua}
+
 \patterngroup[name="conswide"]{ကဃဆဉညဏတထဘယလသဟအဿဟ}
 \patterngroup[name="consnarrow"]{ခဂငစဇဋဌဍဎဒဓနပဖဗမရဝဠၐၑ}
 \patterngroup[name="consmed"]{ကခဂဃငစဆဇဈဉညဋဌဍဎဏတထဒဓနပဖဗဘမယရလဝသဟဠအဿၐၑ}


### PR DESCRIPTION
This should suppress the rash of warnings mentioned in https://github.com/sile-typesetter/fontproof/issues/52 at least until such a time as SILE learns to be a bit nicer about this.